### PR TITLE
Fix rocker gestures description

### DIFF
--- a/settings/en-US.json
+++ b/settings/en-US.json
@@ -523,7 +523,7 @@
         "action": "Action",
         "actionDescription": "Description of the gesture",
         "rockerGesturesEnabled": "Enable rocker gestures",
-        "rockerGesturesDescription": "By default, hold the right button and click the left button to go back, and hold the left button and click the right button to go forward. (Experimental)",
+        "rockerGesturesDescription": "By default, hold the left button and click the right button to go forward, and hold the right button and click the left button to go back. (Experimental)",
         "rockerLeftRight": "Left → Right",
         "rockerLeftRightDescription": "Hold left button, then click right button",
         "rockerRightLeft": "Right → Left",

--- a/settings/en-US.json
+++ b/settings/en-US.json
@@ -523,7 +523,7 @@
         "action": "Action",
         "actionDescription": "Description of the gesture",
         "rockerGesturesEnabled": "Enable rocker gestures",
-        "rockerGesturesDescription": "Right-click and move left to go back, right-click and move right to go forward. (Experimental)",
+        "rockerGesturesDescription": "By default, hold the right button and click the left button to go back, and hold the left button and click the right button to go forward. (Experimental)",
         "rockerLeftRight": "Left → Right",
         "rockerLeftRightDescription": "Hold left button, then click right button",
         "rockerRightLeft": "Right → Left",


### PR DESCRIPTION
# What
Updated the `rockerGesturesDescription` string in `settings/en-US.json` to match the order of settings in the UI.

# Why
The previous text mistakenly described mouse gestures. This update accurately reflects the actual actions of rocker gestures and aligns the description with the UI sequence (Left → Right first) for better clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated rocker gesture instructions in Mouse Gesture settings. Changed from right-click and move navigation to hold-and-click method for forward/back navigation. Feature labeled as experimental.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->